### PR TITLE
Do not mix tabs with spaces + fix build on osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,18 +32,17 @@ include_directories(${LIBRARY_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 ## Declare libraries
 add_library(liburg_c ${LIBRARY_SRC_DIR}/urg_sensor.c
-	                 ${LIBRARY_SRC_DIR}/urg_utils.c
-	                 ${LIBRARY_SRC_DIR}/urg_debug.c
-	                 ${LIBRARY_SRC_DIR}/urg_connection.c
-	                 ${LIBRARY_SRC_DIR}/urg_ring_buffer.c
-	                 ${LIBRARY_SRC_DIR}/urg_serial.c
-	                 ${LIBRARY_SRC_DIR}/urg_serial_utils.c
-	                 ${LIBRARY_SRC_DIR}/urg_tcpclient.c
-	                 ${LIBRARY_SRC_DIR}/urg_time.c
-
+                 ${LIBRARY_SRC_DIR}/urg_utils.c
+                 ${LIBRARY_SRC_DIR}/urg_debug.c
+                 ${LIBRARY_SRC_DIR}/urg_connection.c
+                 ${LIBRARY_SRC_DIR}/urg_ring_buffer.c
+                 ${LIBRARY_SRC_DIR}/urg_serial.c
+                 ${LIBRARY_SRC_DIR}/urg_serial_utils.c
+                 ${LIBRARY_SRC_DIR}/urg_tcpclient.c
+                 ${LIBRARY_SRC_DIR}/urg_time.c
 )
 if(NOT ANDROID)
-	target_link_libraries(liburg_c -lrt -lm)
+  target_link_libraries(liburg_c -lrt -lm)
 endif(NOT ANDROID)
 
 add_library(open_urg_sensor ${LIBRARY_SAMPLE_DIR}/open_urg_sensor.c)
@@ -90,7 +89,7 @@ target_link_libraries(timeout_test liburg_c open_urg_sensor ${catkin_LIBRARIES})
 ## Mark executables and/or libraries for installation
 install(TARGETS liburg_c open_urg_sensor angle_convert_test calculate_xy find_port
                 get_distance get_distance_intensity get_multiecho get_multiecho_intensity
-	            reboot_test sensor_parameter sync_time_stamp timeout_test
+                reboot_test sensor_parameter sync_time_stamp timeout_test
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,9 @@ add_library(liburg_c ${LIBRARY_SRC_DIR}/urg_sensor.c
                  ${LIBRARY_SRC_DIR}/urg_tcpclient.c
                  ${LIBRARY_SRC_DIR}/urg_time.c
 )
-if(NOT ANDROID)
+if(NOT ANDROID AND NOT APPLE)
   target_link_libraries(liburg_c -lrt -lm)
-endif(NOT ANDROID)
+endif(NOT ANDROID AND NOT APPLE)
 
 add_library(open_urg_sensor ${LIBRARY_SAMPLE_DIR}/open_urg_sensor.c)
 target_link_libraries(open_urg_sensor -lm liburg_c ${catkin_LIBRARIES})


### PR DESCRIPTION
This PR fixes two issues:
1) Do not mix tabs with spaces (never a good idea)
2) Fix build on OSX (`rt` does not exist on OSX, and it is not necessary to link to `m` on OSX)